### PR TITLE
Add skill download tracking

### DIFF
--- a/packages/web/src/components/InstallSkill.tsx
+++ b/packages/web/src/components/InstallSkill.tsx
@@ -20,9 +20,7 @@ const CLIENTS: Client[] = [
 ];
 
 export function InstallSkill({ skill }: Props) {
-	const downloadUrl = `https://github-zip-api.val.run/zip?source=${encodeURIComponent(
-		skill.sourceUrl,
-	)}`;
+	const downloadUrl = `/api/download?namespace=${encodeURIComponent(skill.namespace)}`;
 
 	const renderClaudeInstructions = () => {
 		return (

--- a/packages/web/src/pages/api/download.ts
+++ b/packages/web/src/pages/api/download.ts
@@ -1,0 +1,73 @@
+import type { APIRoute } from "astro";
+
+export const GET: APIRoute = async ({ request }) => {
+	const url = new URL(request.url);
+	const namespace = url.searchParams.get("namespace");
+
+	// 1. Validate namespace
+	if (!namespace) {
+		return new Response(
+			JSON.stringify({ error: "Missing namespace parameter" }),
+			{ status: 400, headers: { "Content-Type": "application/json" } },
+		);
+	}
+
+	// 2. Parse namespace (owner/marketplace/skillName)
+	const parts = namespace.split("/");
+	if (parts.length !== 3) {
+		return new Response(
+			JSON.stringify({ error: "Invalid namespace format" }),
+			{ status: 400, headers: { "Content-Type": "application/json" } },
+		);
+	}
+	const [owner, marketplace, skillName] = parts;
+
+	// 3. Track install (fire-and-forget - don't await)
+	fetch(
+		`https://api.claude-plugins.dev/api/skills/${owner}/${marketplace}/${skillName}/install`,
+		{ method: "POST" },
+	).catch((err) => console.error("Tracking failed:", err));
+
+	// 4. Fetch skill to get sourceUrl
+	try {
+		const skillResponse = await fetch(
+			`https://api.claude-plugins.dev/api/skills/${owner}/${marketplace}/${skillName}`,
+		);
+
+		if (!skillResponse.ok) {
+			return new Response(
+				JSON.stringify({ error: "Skill not found" }),
+				{ status: 404, headers: { "Content-Type": "application/json" } },
+			);
+		}
+
+		const skill = await skillResponse.json();
+
+		// 5. Proxy to github-zip-api
+		const zipUrl = `https://github-zip-api.val.run/zip?source=${encodeURIComponent(skill.sourceUrl)}`;
+		const zipResponse = await fetch(zipUrl);
+
+		if (!zipResponse.ok) {
+			return new Response(
+				JSON.stringify({ error: "Failed to fetch zip file" }),
+				{ status: 502, headers: { "Content-Type": "application/json" } },
+			);
+		}
+
+		// 6. Stream response
+		return new Response(zipResponse.body, {
+			status: 200,
+			headers: {
+				"Content-Type": "application/zip",
+				"Content-Disposition": `attachment; filename="${skillName}.zip"`,
+				"Cache-Control": "no-cache",
+			},
+		});
+	} catch (error) {
+		console.error("Download proxy error:", error);
+		return new Response(
+			JSON.stringify({ error: "Internal server error" }),
+			{ status: 500, headers: { "Content-Type": "application/json" } },
+		);
+	}
+};


### PR DESCRIPTION
Implements download tracking by proxying skill downloads through a new API endpoint that increments the install counter before streaming the zip file.

## Changes

- **New API Route** (`packages/web/src/pages/api/download.ts`):
  - Accepts namespace query parameter (owner/marketplace/skillName)
  - Validates namespace format and fetches skill metadata
  - Tracks downloads via POST to registry API (fire-and-forget)
  - Proxies zip file from github-zip-api.val.run with streaming
  - Graceful error handling (400, 404, 502, 500)

- **Updated InstallSkill Component** (`packages/web/src/components/InstallSkill.tsx`):
  - Changed download URL from direct github-zip-api link to proxy endpoint
  - Now uses skill namespace instead of sourceUrl

🤖 Generated with [Claude Code](https://claude.com/claude-code)