### PR TITLE
Fix scrollbar from obscuring command text

### DIFF
--- a/packages/web/src/components/CommandBox.tsx
+++ b/packages/web/src/components/CommandBox.tsx
@@ -39,7 +39,7 @@ export function CommandBox({
       {...props}
     >
       <span className="select-none text-muted-foreground/50 text-[10px]">$</span>
-      <span className="flex-1 whitespace-nowrap text-muted-foreground group-hover:text-foreground transition-colors text-[11px] overflow-auto scroll-smooth">
+      <span className="flex-1 whitespace-nowrap text-muted-foreground group-hover:text-foreground transition-colors text-[11px] overflow-auto scroll-smooth scrollbar-hide">
         {command}
       </span>
       <CopyInstallButton ref={copyButtonRef} command={command} />

--- a/packages/web/src/styles/global.css
+++ b/packages/web/src/styles/global.css
@@ -197,6 +197,14 @@
     @apply border-border outline-ring/50;
   }
 
+  .scrollbar-hide {
+    -ms-overflow-style: none;  /* IE and Edge */
+    scrollbar-width: none;  /* Firefox */
+  }
+  .scrollbar-hide::-webkit-scrollbar {
+    display: none;  /* Chrome, Safari, Opera */
+  }
+
   body {
     @apply bg-background text-foreground;
 


### PR DESCRIPTION
- Add `.scrollbar-hide` utility class in `global.css` with cross-browser support (Chrome, Firefox, Safari, Edge)
- Apply `scrollbar-hide` to CommandBox command span to prevent scrollbar from obscuring command text
- Preserve horizontal scroll functionality for long installation commands