### PR TITLE
Add package manager toggle to skill install widget

### DIFF
--- a/packages/web/src/components/CommandBoxWithRunner.tsx
+++ b/packages/web/src/components/CommandBoxWithRunner.tsx
@@ -1,0 +1,53 @@
+import { useState } from "react";
+import { CommandBox } from "./CommandBox";
+import { cn } from "@/lib/utils";
+
+type PackageRunner = "npm" | "bun" | "pnpm" | "yarn";
+
+type RunnerConfig = {
+  id: PackageRunner;
+  label: string;
+  prefix: string;
+};
+
+const RUNNERS: RunnerConfig[] = [
+  { id: "npm", label: "npm", prefix: "npx" },
+  { id: "bun", label: "bun", prefix: "bunx" },
+  { id: "pnpm", label: "pnpm", prefix: "pnpm dlx" },
+  { id: "yarn", label: "yarn", prefix: "yarn dlx" },
+];
+
+type Props = {
+  command: string;
+  className?: string;
+};
+
+export function CommandBoxWithRunner({ command, className }: Props) {
+  const [selectedRunner, setSelectedRunner] = useState<PackageRunner>("npm");
+
+  const runner = RUNNERS.find((r) => r.id === selectedRunner)!;
+  const fullCommand = `${runner.prefix} ${command}`;
+
+  return (
+    <div className={cn("flex flex-col gap-1.5", className)}>
+      <div className="flex items-center gap-1 bg-muted/50 rounded-md p-0.5 w-fit">
+        {RUNNERS.map((r) => (
+          <button
+            key={r.id}
+            type="button"
+            onClick={() => setSelectedRunner(r.id)}
+            className={cn(
+              "px-2 py-1 text-[10px] font-medium rounded transition-colors",
+              selectedRunner === r.id
+                ? "bg-primary text-primary-foreground"
+                : "text-muted-foreground hover:text-foreground hover:bg-muted"
+            )}
+          >
+            {r.label}
+          </button>
+        ))}
+      </div>
+      <CommandBox command={fullCommand} />
+    </div>
+  );
+}

--- a/packages/web/src/components/InstallSkill.tsx
+++ b/packages/web/src/components/InstallSkill.tsx
@@ -1,7 +1,7 @@
 import { DownloadIcon } from "./ui/download";
 import { ClaudeCodeIcon, ClaudeIcon } from "@/components/ui/claude-icons";
 import { PackageIcon } from "@/components/ui/package-icon";
-import { CommandBox } from "@/components/CommandBox";
+import { CommandBoxWithRunner } from "@/components/CommandBoxWithRunner";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import type { Skill } from "@/lib/api";
 import { CodexIcon } from "./ui/codex-icon";
@@ -106,8 +106,8 @@ export function InstallSkill({ skill }: Props) {
 	};
 
 	const renderCliInstructions = (clientId: string, supportsGlobal: boolean) => {
-		const projectSkill = `npx skills-installer install ${skill.namespace} --local --client ${clientId}`;
-		const personalSkill = `npx skills-installer install ${skill.namespace} --client ${clientId}`;
+		const projectSkill = `skills-installer install ${skill.namespace} --local --client ${clientId}`;
+		const personalSkill = `skills-installer install ${skill.namespace} --client ${clientId}`;
 
 		return (
 			<div className="flex flex-col gap-4">
@@ -125,7 +125,7 @@ export function InstallSkill({ skill }: Props) {
 							<p className="text-sm text-muted-foreground">
 								Applies to all projects globally.
 							</p>
-							<CommandBox command={personalSkill} />
+							<CommandBoxWithRunner command={personalSkill} />
 						</div>
 						<div className="flex flex-col gap-2">
 							<div className="flex items-center gap-2">
@@ -139,7 +139,7 @@ export function InstallSkill({ skill }: Props) {
 							<p className="text-sm text-muted-foreground">
 								Applies to current project only. Run this command in your project root.
 							</p>
-							<CommandBox command={projectSkill} />
+							<CommandBoxWithRunner command={projectSkill} />
 						</div>
 					</>
 				) : (
@@ -155,7 +155,7 @@ export function InstallSkill({ skill }: Props) {
 						<p className="text-sm text-muted-foreground">
 							Run this command in your project root.
 						</p>
-						<CommandBox command={projectSkill} />
+						<CommandBoxWithRunner command={projectSkill} />
 					</div>
 				)}
 			</div>


### PR DESCRIPTION
Adds CommandBoxWithRunner component that wraps CommandBox with a
toggle to switch between npm (npx), bun (bunx), pnpm (pnpm dlx),
and yarn (yarn dlx) package runners.

Closes #48