### PR TITLE
fix(workflow): support publishing both skills-installer and claude-plugins packages

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -35,7 +35,9 @@ jobs:
       - run: bun run build
         working-directory: ${{ steps.pkg.outputs.dir }}
       
+      - name: Setup npm authentication
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.npm_token }}" > ~/.npmrc
+      
       - run: npm publish
         working-directory: ${{ steps.pkg.outputs.dir }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.npm_token }}


### PR DESCRIPTION
## Summary

Fixes the npm publish workflow to support both `skills-installer` and `claude-plugins` packages by detecting which package a release is for based on the tag name.

## Problem

The workflow was hardcoded to only work with `packages/cli` (claude-plugins), causing the recent `skills-installer@0.1.4` release to fail with:
```
error: Missing entrypoints. What would you like to bundle?
```

## Changes

### 1. Dynamic package detection
- Added step to detect package from release tag name
- `skills-installer@*` → `packages/skills-installer`
- `claude-plugins@*` → `packages/cli`

### 2. Fixed build command
- Changed from `bun build` (no arguments) to `bun run build` (executes package.json script)
- Both packages have proper build scripts defined

### 3. Removed hardcoded working directory
- Each step now uses detected package directory dynamically
- Tests, builds, and publishes from the correct location

### 4. Minor improvements
- Removed deprecated `registry-url` parameter (causing warnings)
- Changed `bun publish` to `npm publish` for better token auth compatibility

Fixes #N/A (failed workflow run: https://github.com/Kamalnrf/claude-plugins/actions/runs/20956355722)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched package publishing from GitHub Packages to npm.
  * Added support for publishing multiple packages based on release tag patterns.
  * Split publish flow into explicit test, build and publish steps.
  * Ensures each step runs in the resolved package directory instead of a global working directory.
  * Added npm authentication setup prior to publish and removed the previous registry-url input.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->