### PR TITLE
fix: add browser cache revalidation headers to prevent stale HTML after deploys

### DIFF
--- a/packages/web/src/pages/index.astro
+++ b/packages/web/src/pages/index.astro
@@ -27,7 +27,7 @@ const { plugins, total } = await registryAPI.searchPlugins({
 // Search/filter happens client-side via /api/plugins (excluded from ISR)
 const hasQueryParams = searchQuery || hasSkills || orderBy || order;
 if (!hasQueryParams) {
-	Astro.response.headers.set('Cache-Control', 'public, s-maxage=7200, stale-while-revalidate=14400');
+	Astro.response.headers.set('Cache-Control', 'public, max-age=0, must-revalidate, s-maxage=7200, stale-while-revalidate=14400');
 }
 ---
 

--- a/packages/web/src/pages/skills/[...slug].astro
+++ b/packages/web/src/pages/skills/[...slug].astro
@@ -32,7 +32,7 @@ const keywords = `Agent Skills, ${skill.name}, ${owner}, ${marketplace}, Claude,
 const ogImageAlt = `${skill.name} - Agent skill for AI coding assistants with ${skill.stars} stars and ${skill.installs} installs`;
 
 // ISR: Cache for 6 hours with 12 hour stale-while-revalidate
-Astro.response.headers.set('Cache-Control', 'public, s-maxage=21600, stale-while-revalidate=43200');
+Astro.response.headers.set('Cache-Control', 'public, max-age=0, must-revalidate, s-maxage=21600, stale-while-revalidate=43200');
 ---
 
 <MarketplaceLayout

--- a/packages/web/src/pages/skills/index.astro
+++ b/packages/web/src/pages/skills/index.astro
@@ -26,7 +26,7 @@ const { skills, total } = await registryAPI.searchSkills({
 // Search/filter happens client-side via /api/skills (excluded from ISR)
 const hasQueryParams = searchQuery || orderBy || order;
 if (!hasQueryParams) {
-	Astro.response.headers.set('Cache-Control', 'public, s-maxage=7200, stale-while-revalidate=14400');
+	Astro.response.headers.set('Cache-Control', 'public, max-age=0, must-revalidate, s-maxage=7200, stale-while-revalidate=14400');
 }
 ---
 


### PR DESCRIPTION
## Problem

Safari was caching HTML pages locally and serving stale versions after deployments. The stale HTML referenced old JS bundles that no longer existed, causing JavaScript to appear disabled.

## Solution

Added `max-age=0, must-revalidate` to Cache-Control headers on HTML pages:

- Browsers now must check with the server before using cached HTML
- Vercel CDN (`s-maxage`) still caches normally for performance
- Prevents browsers from serving stale HTML referencing old JS bundles after deploys

## Changes

- `packages/web/src/pages/index.astro`
- `packages/web/src/pages/skills/index.astro`
- `packages/web/src/pages/skills/[...slug].astro`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized cache management for improved performance and content freshness across key pages. Browser-level caching policies have been refined to ensure users receive updated content more reliably while maintaining efficient server-side caching for better overall performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->