### PR TITLE
feat(web): add autonomous skill discovery section with embedded tweet to skills-discovery page

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -30,7 +30,7 @@
     },
     "packages/skills-installer": {
       "name": "skills-installer",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "bin": {
         "skills-installer": "./dist/cli.js",
       },
@@ -1276,7 +1276,7 @@
 
     "unicode-properties/base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
-    "web/@types/bun": ["@types/bun@1.3.5", "", { "dependencies": { "bun-types": "1.3.5" } }, "sha512-RnygCqNrd3srIPEWBd5LFeUYG7plCoH2Yw9WaZGyNmdTEei+gWaHqydbaIRkIkcbXwhBT94q78QljxN0Sk838w=="],
+    "web/@types/bun": ["@types/bun@1.3.6", "", { "dependencies": { "bun-types": "1.3.6" } }, "sha512-uWCv6FO/8LcpREhenN1d1b6fcspAB+cefwD7uti8C8VffIv0Um08TKMn98FynpTiU38+y2dUO55T11NgDt8VAA=="],
 
     "wrap-ansi-cjs/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
@@ -1295,6 +1295,8 @@
     "gray-matter/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
     "string-width-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "web/@types/bun/bun-types": ["bun-types@1.3.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-OlFwHcnNV99r//9v5IIOgQ9Uk37gZqrNMCcqEaExdkVq3Avwqok1bJFmvGMCkCE0FqzdY8VMOZpfpR3lwI+CsQ=="],
 
     "wrap-ansi-cjs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 

--- a/packages/web/src/components/TweetEmbed.tsx
+++ b/packages/web/src/components/TweetEmbed.tsx
@@ -1,0 +1,97 @@
+import { useEffect, useRef, useState } from "react";
+
+declare global {
+	interface Window {
+		twttr?: {
+			widgets: {
+				createTweet: (
+					id: string,
+					element: HTMLElement,
+					options?: { theme?: string }
+				) => Promise<HTMLElement>;
+			};
+		};
+	}
+}
+
+interface TweetEmbedProps {
+	id: string;
+}
+
+function TweetSkeleton() {
+	return (
+		<div className="w-full rounded-xl border border-border/50 bg-card/50 p-4 animate-pulse">
+			<div className="flex items-center gap-3 mb-3">
+				<div className="w-10 h-10 rounded-full bg-muted/50" />
+				<div className="flex flex-col gap-1.5">
+					<div className="w-24 h-4 rounded bg-muted/50" />
+					<div className="w-16 h-3 rounded bg-muted/50" />
+				</div>
+			</div>
+			<div className="flex flex-col gap-2 mb-3">
+				<div className="w-full h-4 rounded bg-muted/50" />
+				<div className="w-3/4 h-4 rounded bg-muted/50" />
+			</div>
+			<div className="w-full h-48 rounded-lg bg-muted/50" />
+		</div>
+	);
+}
+
+const TWITTER_SCRIPT_URL = "https://platform.twitter.com/widgets.js";
+
+export function TweetEmbed({ id }: TweetEmbedProps) {
+	const containerRef = useRef<HTMLDivElement>(null);
+	const [isLoading, setIsLoading] = useState(true);
+
+	useEffect(() => {
+		if (!containerRef.current) return;
+
+		let isMounted = true;
+
+		const renderTweet = async () => {
+			if (!isMounted || !window.twttr || !containerRef.current) return;
+
+			containerRef.current.innerHTML = "";
+			await window.twttr.widgets.createTweet(id, containerRef.current, {
+				theme: "dark",
+			});
+
+			if (isMounted) {
+				setIsLoading(false);
+			}
+		};
+
+		// If Twitter API is ready, render immediately
+		if (window.twttr) {
+			renderTweet();
+		} else {
+			// Load script if not already in DOM, then render
+			let script = document.querySelector<HTMLScriptElement>(
+				`script[src="${TWITTER_SCRIPT_URL}"]`
+			);
+
+			if (!script) {
+				script = document.createElement("script");
+				script.src = TWITTER_SCRIPT_URL;
+				script.async = true;
+				document.body.appendChild(script);
+			}
+
+			script.addEventListener("load", renderTweet);
+		}
+
+		return () => {
+			isMounted = false;
+		};
+	}, [id]);
+
+	return (
+		<div className="flex justify-center w-full max-w-[550px] mx-auto">
+			{isLoading && <TweetSkeleton />}
+			<div
+				ref={containerRef}
+				className={isLoading ? "hidden" : "w-full [&>div]:!mx-auto"}
+			/>
+		</div>
+	);
+}

--- a/packages/web/src/layouts/MarketplaceLayout.astro
+++ b/packages/web/src/layouts/MarketplaceLayout.astro
@@ -67,6 +67,9 @@ const fullOgImage = ogImage.startsWith('http') ? ogImage : `${siteUrl}${ogImage}
 
     <!-- Custom head slot for additional meta tags -->
     <slot name="head" />
+
+    <!-- Preload Twitter widgets for faster tweet embeds -->
+    <link rel="preload" href="https://platform.twitter.com/widgets.js" as="script" />
     
     <ClientRouter />
   </head>

--- a/packages/web/src/pages/skills/[...slug].astro
+++ b/packages/web/src/pages/skills/[...slug].astro
@@ -4,6 +4,7 @@ import JsonLd from "../../components/JsonLd.astro";
 import { registryAPI } from "../../lib/api";
 import { InstallSkill } from "../../components/InstallSkill";
 import { SkillDetailHeader } from "@/components/SkillDetailHeader";
+import { TweetEmbed } from "@/components/TweetEmbed";
 import Markdown from "@/components/Markdown.astro";
 import { Button } from "@/components/ui/button";
 import {LinkIcon} from '@/components/ui/link-icon'
@@ -63,6 +64,15 @@ Astro.response.headers.set('Cache-Control', 'public, max-age=0, must-revalidate,
 	</Fragment>
 	<div class="flex flex-col p-6 gap-4">
 	  <SkillDetailHeader client:load skill={skill} />
+		{slug === "@Kamalnrf/claude-plugins/skills-discovery" && (
+			<section>
+				<div class="flex items-center gap-2 py-2">
+					<h2 class="text-base font-semibold text-foreground/90 tracking-tight">Autonomous Skill Discovery</h2>
+					<div class="flex-1 h-px bg-border/30"></div>
+				</div>
+				<TweetEmbed client:only="react" id="2011227015337455694" />
+			</section>
+		)}
 		<section>
       <div class="flex items-center gap-2 py-2">
         <h2 class="text-base font-semibold text-foreground/90 tracking-tight">Install Skill</h2>


### PR DESCRIPTION
## Summary
Adds a new "Autonomous Skill Discovery" section to the skills-discovery detail page featuring an embedded tweet showcasing the meta skill in action.

## Changes

### New Section
- **Placement**: Positioned above "Install Skill" section on `/skills/@Kamalnrf/claude-plugins/skills-discovery`
- **Conditional rendering**: Only displays on skills-discovery page
- **Dark theme**: Tweet uses dark theme to match site aesthetic

### Technical Details
- Uses Twitter's official embed (blockquote + widgets.js) for full functionality including video playback
- Created reusable `TweetEmbed` component

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrated tweet embedding so tweets can be displayed directly within the app.
  * Added an "Autonomous Skill Discovery" section that shows embedded tweets for the specified skill view.
  * Preloaded Twitter widgets to improve embed loading performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->