### PR TITLE
Add Discord badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A plugin manager and skills installer for AI coding agents.
 [![claude-plugins](https://img.shields.io/npm/v/claude-plugins?label=claude-plugins)](https://www.npmjs.com/package/claude-plugins)
 [![skills-installer](https://img.shields.io/npm/v/skills-installer?label=skills-installer)](https://www.npmjs.com/package/skills-installer)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Discord](https://img.shields.io/discord/1320743242672635965?label=Discord&logo=discord&logoColor=white&color=5865F2)](https://discord.gg/Pt9uN4FXR4)
 
 <div align="center">
   <video src="https://github.com/user-attachments/assets/63582572-397d-4104-8efe-ab844a0f43f0" />


### PR DESCRIPTION
## Summary
- Adds Discord badge with live member count to README badge list
- Badge links to Discord server invite: https://discord.gg/Pt9uN4FXR4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Discord community badge to the README's top badges section to enhance project visibility and community engagement options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->