### PR TITLE
Add fix for OpenCode agent skills directory location

### DIFF
--- a/packages/skills-installer/package.json
+++ b/packages/skills-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skills-installer",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Install agent skills across multiple clients that support agentskills.io",
   "type": "module",
   "bin": {
@@ -24,27 +24,27 @@
   "devDependencies": {
     "bun-types": "latest"
   },
-	"keywords": [
-		"skills",
-		"claude-code",
-		"codex",
-		"amp",
-		"cursor",
-		"gemini",
-		"goose",
-		"letta",
-		"opencode",
-		"vscode",
-		"windsurf",
-		"antigravity",
-		"trae",
-		"qoder",
-		"codebuddy",
-		"copilot",
-		"agent",
-		"cli",
-		"installer"
-	],
+  "keywords": [
+    "skills",
+    "claude-code",
+    "codex",
+    "amp",
+    "cursor",
+    "gemini",
+    "goose",
+    "letta",
+    "opencode",
+    "vscode",
+    "windsurf",
+    "antigravity",
+    "trae",
+    "qoder",
+    "codebuddy",
+    "copilot",
+    "agent",
+    "cli",
+    "installer"
+  ],
   "author": "Kamal <https://github.com/Kamalnrf>",
   "license": "MIT"
 }

--- a/packages/skills-installer/src/lib/client-config.ts
+++ b/packages/skills-installer/src/lib/client-config.ts
@@ -42,7 +42,7 @@ export const CLIENT_CONFIGS: Record<string, ClientConfig> = {
 	},
 	"opencode": {
 		name: "OpenCode",
-		globalDir: join(homedir(), ".opencode", "skill"),
+		globalDir: join(homedir(), ".config/", "opencode", "skill"),
 		localDir: join(process.cwd(), ".opencode", "skill"),
 	},
 	"gemini": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.1.7
  * Updated OpenCode client configuration directory path from ~/.opencode/skill to ~/.config/opencode/skill

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->