### PR TITLE
Fix plugin name: compounding-engineering → compound-engineering

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A plugin manager and skills installer for AI coding agents.
 
 **Install a Claude plugin:**
 ```bash
-npx claude-plugins install @EveryInc/every-marketplace/compounding-engineering
+npx claude-plugins install @EveryInc/every-marketplace/compound-engineering
 ```
 
 > [!IMPORTANT]

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -19,7 +19,7 @@ npm install -g claude-plugins
 Or use directly with `npx`:
 
 ```bash
-npx claude-plugins install @EveryInc/every-marketplace/compounding-engineering
+npx claude-plugins install @EveryInc/every-marketplace/compound-engineering
 ```
 
 Plugins are installed to `~/.claude/plugins/marketplaces/`
@@ -44,23 +44,23 @@ Claude Plugins are custom collections of slash commands, agents, MCP servers, an
 Plugins are identified using the format: `@owner/marketplace/plugin-name`
 
 Examples:
-- `@EveryInc/every-marketplace/compounding-engineering`
+- `@EveryInc/every-marketplace/compound-engineering`
 - `@anthropics/claude-code-plugins/pr-review-toolkit`
 
 ## Examples
 
 ```bash
 # Install a plugin
-claude-plugins install @EveryInc/every-marketplace/compounding-engineering
+claude-plugins install @EveryInc/every-marketplace/compound-engineering
 
 # List all installed plugins
 claude-plugins list
 
 # Disable a plugin temporarily
-claude-plugins disable compounding-engineering
+claude-plugins disable compound-engineering
 
 # Re-enable it later
-claude-plugins enable compounding-engineering
+claude-plugins enable compound-engineering
 ```
 
 ## Development


### PR DESCRIPTION
## Summary
This PR corrects the plugin name from `compounding-engineering` to `compound-engineering` across documentation files.

## Changes
- Updated all references to the EveryInc marketplace plugin in README files
- Corrected plugin name in installation examples
- Fixed plugin name in enable/disable command examples
- Updated plugin identifier examples in documentation

## Files Modified
- `packages/cli/README.md` - Updated 4 references to the plugin name
- `README.md` - Updated 1 reference to the plugin name

This appears to be a documentation correction to align with the actual plugin name in the marketplace.

https://claude.ai/code/session_01RnTvG5gX2Ng6dR8HUS2Q4P

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Quick Start installation instructions and usage example documentation across README files to reference the correct plugin package identifier. These corrections ensure users receive accurate guidance when installing the plugin and can properly reference the package in their configurations. Consistent documentation helps prevent installation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->