### PR TITLE
Support shared skill install targets

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -30,7 +30,7 @@
     },
     "packages/skills-installer": {
       "name": "skills-installer",
-      "version": "0.1.4",
+      "version": "0.3.0",
       "bin": {
         "skills-installer": "./dist/cli.js",
       },

--- a/packages/skills-installer/README.md
+++ b/packages/skills-installer/README.md
@@ -7,7 +7,7 @@ Browse and discover available skills at [claude-plugins.dev/skills](https://clau
 
 - 🔍 **Interactive Search** - Discover and install skills interactively
 - 🚀 **Simple CLI** - Clean, intuitive command-line interface
-- 📦 **Universal Registry** - Access skills all public agent skills
+- 📦 **Skill Registry** - Access public agent skills
 - 🌍 **Global & Local** - Install skills globally or per-project
 - 🎯 **Multi-Client Support** - Install skills for different coding clients
 
@@ -67,6 +67,12 @@ skills-installer install anthropics/claude-code
 # Install a specific skill
 skills-installer install anthropics/claude-code/frontend-design
 
+# Install all skills resolved from an owner or repo
+skills-installer install anthropics/claude-code --all
+
+# `add` is an alias for `install`
+skills-installer add anthropics/claude-code/frontend-design
+
 # Install from any GitHub URL
 skills-installer install https://github.com/owner/repo/tree/main/skills/my-skill
 ```
@@ -100,31 +106,23 @@ Shows all installed skills with their installation scope (global/project) and pa
 ### Target specific clients
 
 ```bash
-skills-installer install @anthropics/skills/xlsx --client cursor
+skills-installer install @anthropics/skills/xlsx --client shared
 ```
 
 Currently supported clients:
-- `claude-code` (default)
-- `amp`
-- `codex`
-- `cursor`
-- `windsurf`
-- `github`
-- `vscode`
-- `gemini`
-- `goose`
-- `letta`
-- `opencode`
-- `antigravity`
-- `trae`
-- `qoder`
-- `codebuddy`
+- `shared` - `.agents/skills`, used by Codex, Amp, Warp, Cursor, OpenCode, Cline, Gemini CLI, GitHub Copilot, and more
+- `claude-code` - `.claude/skills`
+- `openclaw` - `skills` in the project, `~/.openclaw/skills` globally
+- `pi` - `.pi/skills` in the project, `~/.pi/agent/skills` globally
+
+Common agent IDs that use `.agents/skills` are accepted as aliases for `shared`, including `opencode`, `codex`, `cursor`, `cline`, `amp`, `warp`, and `github-copilot`.
 
 ## Commands
 
 | Command | Description |
 |---------|-------------|
 | `search [query]` | Search across all public skills on GitHub |
+| `add owner` | Alias for `install owner` |
 | `install owner` | Browse all skills from owner's repos |
 | `install owner/repo` | Browse skills in a specific repo |
 | `install owner/repo/skill` | Install a specific skill |
@@ -135,8 +133,9 @@ Currently supported clients:
 
 | Option | Alias | Description |
 |--------|-------|-------------|
-| `--client <name>` | | Target AI coding client (default: claude-code) |
+| `--client <name>` | | Target install location |
 | `--project` | `-p` | Install to current project directory |
+| `--all` | | Install all resolved skills without opening the skill selector |
 
 ## Skill Identifier Format
 
@@ -149,11 +148,12 @@ Skills can be identified using multiple formats:
 
 ## Where are skills installed?
 
-**Global installation (claude-code):**
-- `~/.claude/skills/`
-
-**Project installation:**
-- `./.claude/skills/` (in your current directory)
+| Client | Project path | Global path |
+|--------|--------------|-------------|
+| `shared` | `./.agents/skills/` | `~/.config/agents/skills/` |
+| `claude-code` | `./.claude/skills/` | `~/.claude/skills/` |
+| `openclaw` | `./skills/` | `~/.openclaw/skills/` |
+| `pi` | `./.pi/skills/` | `~/.pi/agent/skills/` |
 
 ## Examples
 
@@ -179,8 +179,8 @@ skills-installer install anthropics/claude-code/frontend-design --project
 # Install from a GitHub URL
 skills-installer install https://github.com/owner/repo/tree/main/skills/my-skill
 
-# Install skill for a specific client
-skills-installer install anthropics/claude-code/frontend-design --client cursor
+# Install skill to the shared .agents/skills location
+skills-installer install anthropics/claude-code/frontend-design --client shared
 
 # List all installed skills
 skills-installer list

--- a/packages/skills-installer/package.json
+++ b/packages/skills-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skills-installer",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Install agent skills across multiple clients that support agentskills.io",
   "type": "module",
   "bin": {

--- a/packages/skills-installer/src/cli.ts
+++ b/packages/skills-installer/src/cli.ts
@@ -43,6 +43,7 @@ ${pc.bold(pc.cyan("skills-installer"))} ${pc.dim("—")} Install agent skills
 ${pc.bold(pc.yellow("COMMANDS:"))}
   ${pc.green("search")} [query]             ${pc.dim("Search across all public skills on GitHub")}
   ${pc.green("install")} owner              ${pc.dim("Browse all skills from owner's repos")}
+  ${pc.green("add")} owner                  ${pc.dim("Alias for install")}
   ${pc.green("install")} owner/repo         ${pc.dim("Browse skills in a specific repo")}
   ${pc.green("install")} owner/repo/skill   ${pc.dim("Install a specific skill")}
   ${pc.green("install")} <git-url>          ${pc.dim("HTTPS, SSH, or direct path to skill")}
@@ -51,11 +52,13 @@ ${pc.bold(pc.yellow("COMMANDS:"))}
 ${pc.bold(pc.yellow("EXAMPLES:"))}
   ${pc.cyan("$")} skills-installer search ${pc.magenta('frontend')}
   ${pc.cyan("$")} skills-installer install ${pc.magenta("anthropics")}
+  ${pc.cyan("$")} skills-installer add ${pc.magenta("anthropics/claude-code")} ${pc.blue("--all")}
   ${pc.cyan("$")} skills-installer install ${pc.magenta("anthropics/claude-code")}
 
 ${pc.bold(pc.yellow("OPTIONS:"))}
   ${pc.blue("--client")} <name>   Target client (${getAvailableClients().join(", ")})
   ${pc.blue("--project")}, ${pc.blue("-p")}     Install to current project directory
+  ${pc.blue("--all")}            Install all resolved skills without selecting
 
 ${pc.dim("Browse skills at")} ${pc.underline(pc.cyan("https://claude-plugins.dev/skills"))}
 `);
@@ -79,12 +82,13 @@ const main = async () => {
 
 	try {
 		switch (command) {
-			case "install": {
+			case "install":
+			case "add": {
 				const skillId = positional[0];
 				if (!skillId) {
 					cancel("Skill identifier required");
 					console.log(
-						pc.dim("Usage: skills-installer install @owner/repo/skill"),
+						pc.dim(`Usage: skills-installer ${command} @owner/repo/skill`),
 					);
 					process.exit(1);
 				}
@@ -97,6 +101,7 @@ const main = async () => {
 				await install(skillId, {
 					client: flags.client as string,
 					local: useProject,
+					all: !!flags.all,
 				});
 				break;
 			}

--- a/packages/skills-installer/src/commands/install.ts
+++ b/packages/skills-installer/src/commands/install.ts
@@ -12,6 +12,7 @@ import {
 import {
 	resolveTarget,
 	trackInstallation,
+	type ResolveResponse,
 	type ResolvedSkill,
 } from "../lib/api";
 import { downloadSkill } from "../lib/download";
@@ -103,6 +104,25 @@ export async function installSingleSkill(
 	return { name: skill.name, installed, updated, failed };
 }
 
+async function resolveAllSkills(
+	skillId: string,
+	initialResponse: ResolveResponse,
+): Promise<ResolvedSkill[]> {
+	const skills = [...initialResponse.skills];
+	let { hasMore, limit, offset } = initialResponse.page;
+
+	while (hasMore) {
+		const response = await resolveTarget(skillId, {
+			limit,
+			offset: offset + limit,
+		});
+		skills.push(...response.skills);
+		({ hasMore, limit, offset } = response.page);
+	}
+
+	return skills;
+}
+
 /**
  * Install an agent skill
  * Supports: @owner/repo/skill, owner/repo, owner/repo/skill, GitHub URLs
@@ -124,7 +144,7 @@ export async function install(
 		throw error;
 	}
 
-	const skills = response.skills;
+	const skills = options.all ? await resolveAllSkills(skillId, response) : response.skills;
 
 	if (skills.length === 0) {
 		s.stop("No skills found");

--- a/packages/skills-installer/src/commands/install.ts
+++ b/packages/skills-installer/src/commands/install.ts
@@ -144,6 +144,9 @@ export async function install(
 	if (skills.length === 1) {
 		toInstall = skills;
 		note(`Found: ${pc.bold(skills[0]!.name)}`);
+	} else if (options.all) {
+		toInstall = skills;
+		note(`Installing all ${skills.length} skills.`);
 	} else {
 		// Multiple skills - show multiselect
 		const selected = await multiselect({

--- a/packages/skills-installer/src/lib/client-config.ts
+++ b/packages/skills-installer/src/lib/client-config.ts
@@ -1,82 +1,71 @@
+import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import type { ClientConfig } from "../types.js";
 
-// Client configurations
+const home = homedir();
+const configHome = process.env.XDG_CONFIG_HOME?.trim() || join(home, ".config");
+const claudeHome = process.env.CLAUDE_CONFIG_DIR?.trim() || join(home, ".claude");
+
+const getOpenClawGlobalDir = (): string => {
+	if (existsSync(join(home, ".openclaw"))) {
+		return join(home, ".openclaw", "skills");
+	}
+	if (existsSync(join(home, ".clawdbot"))) {
+		return join(home, ".clawdbot", "skills");
+	}
+	if (existsSync(join(home, ".moltbot"))) {
+		return join(home, ".moltbot", "skills");
+	}
+	return join(home, ".openclaw", "skills");
+};
+
+// Primary install targets. Many agents now read project skills from .agents/skills.
 export const CLIENT_CONFIGS: Record<string, ClientConfig> = {
+	"shared": {
+		name: "Shared (.agents/skills)",
+		globalDir: join(configHome, "agents", "skills"),
+		localDir: join(process.cwd(), ".agents", "skills"),
+	},
 	"claude-code": {
 		name: "Claude Code",
-		globalDir: join(homedir(), ".claude", "skills"),
+		globalDir: join(claudeHome, "skills"),
 		localDir: join(process.cwd(), ".claude", "skills"),
 	},
-	"codex": {
-		name: "Codex",
-		globalDir: join(homedir(), ".codex", "skills"),
-		localDir: join(process.cwd(), ".codex", "skills"),
+	"openclaw": {
+		name: "OpenClaw",
+		globalDir: getOpenClawGlobalDir(),
+		localDir: join(process.cwd(), "skills"),
 	},
-	"cursor": {
-		name: "Cursor",
-		localDir: join(process.cwd(), ".cursor", "skills"),
-	},
-	"github": {
-		name: "GitHub",
-		localDir: join(process.cwd(), ".github", "skills"),
-	},
-	"letta": {
-		name: "Letta",
-		localDir: join(process.cwd(), ".skills"),
-	},
-	"vscode": {
-		name: "VS Code",
-		localDir: join(process.cwd(), ".github", "skills"),
-	},
-	"amp": {
-		name: "AMP",
-		globalDir: join(homedir(), ".config", "agents", "skills"),
-		localDir: join(process.cwd(), ".agents", "skills"),
-	},
-	"goose": {
-		name: "Goose",
-		globalDir: join(homedir(), ".config", "goose", "skills"),
-		localDir: join(process.cwd(), ".agents", "skills"),
-	},
-	"opencode": {
-		name: "OpenCode",
-		globalDir: join(homedir(), ".config/", "opencode", "skill"),
-		localDir: join(process.cwd(), ".opencode", "skill"),
-	},
-	"gemini": {
-		name: "Gemini CLI",
-		globalDir: join(homedir(), ".gemini", "skills"),
-		localDir: join(process.cwd(), ".gemini", "skills"),
-	},
-	"windsurf": {
-		name: "Windsurf",
-		globalDir: join(homedir(), ".codeium", "windsurf", "skills"),
-		localDir: join(process.cwd(), ".windsurf", "skills"),
-	},
-	"antigravity": {
-		name: "Antigravity",
-		globalDir: join(homedir(), ".gemini", "antigravity", "skills"),
-		localDir: join(process.cwd(), ".agent", "skills"),
-	},
-	"trae": {
-		name: "Trae",
-		localDir: join(process.cwd(), ".trae", "skills"),
-	},
-	"qoder": {
-		name: "Qoder",
-		globalDir: join(homedir(), ".qoder", "skills"),
-		localDir: join(process.cwd(), ".qoder", "skills"),
-	},
-	"codebuddy": {
-		name: "CodeBuddy",
-		globalDir: join(homedir(), ".codebuddy", "skills"),
-		localDir: join(process.cwd(), ".codebuddy", "skills"),
+	"pi": {
+		name: "Pi",
+		globalDir: join(home, ".pi", "agent", "skills"),
+		localDir: join(process.cwd(), ".pi", "skills"),
 	},
 };
 
+const CLIENT_ALIASES: Record<string, string> = {
+	"agents": "shared",
+	"amp": "shared",
+	"antigravity": "shared",
+	"cline": "shared",
+	"codex": "shared",
+	"cursor": "shared",
+	"deepagents": "shared",
+	"dexto": "shared",
+	"firebender": "shared",
+	"gemini": "shared",
+	"gemini-cli": "shared",
+	"github": "shared",
+	"github-copilot": "shared",
+	"kimi-cli": "shared",
+	"opencode": "shared",
+	"replit": "shared",
+	"vscode": "shared",
+	"warp": "shared",
+};
+
 export const getClientConfig = (name: string): ClientConfig | undefined =>
-	CLIENT_CONFIGS[name];
+	CLIENT_CONFIGS[name] ?? CLIENT_CONFIGS[CLIENT_ALIASES[name] ?? ""];
 
 export const getAvailableClients = (): string[] => Object.keys(CLIENT_CONFIGS);

--- a/packages/skills-installer/src/lib/client-config.ts
+++ b/packages/skills-installer/src/lib/client-config.ts
@@ -7,7 +7,7 @@ const home = homedir();
 const configHome = process.env.XDG_CONFIG_HOME?.trim() || join(home, ".config");
 const claudeHome = process.env.CLAUDE_CONFIG_DIR?.trim() || join(home, ".claude");
 
-const getOpenClawGlobalDir = (): string => {
+const getOpenClawGlobalDir = (): string | undefined => {
 	if (existsSync(join(home, ".openclaw"))) {
 		return join(home, ".openclaw", "skills");
 	}
@@ -17,7 +17,6 @@ const getOpenClawGlobalDir = (): string => {
 	if (existsSync(join(home, ".moltbot"))) {
 		return join(home, ".moltbot", "skills");
 	}
-	return join(home, ".openclaw", "skills");
 };
 
 // Primary install targets. Many agents now read project skills from .agents/skills.

--- a/packages/skills-installer/src/lib/select-scope-and-clients.ts
+++ b/packages/skills-installer/src/lib/select-scope-and-clients.ts
@@ -65,11 +65,14 @@ export async function selectClients(
 ): Promise<string[] | "back" | null> {
 	const clients = getClientsForScope(scope);
 
-	const clientOptions: Array<{ value: string; label: string }> = clients.map((clientId) => {
+	const clientOptions: Array<{ value: string; label: string; hint?: string }> = clients.map((clientId) => {
 		const config = CLIENT_CONFIGS[clientId]!;
 		return {
 			value: clientId,
 			label: config.name,
+			hint: clientId === "shared"
+				? "Codex, Amp, Warp, Cursor, OpenCode, Cline, Gemini CLI, GitHub Copilot"
+				: undefined,
 		};
 	});
 

--- a/packages/skills-installer/src/types.ts
+++ b/packages/skills-installer/src/types.ts
@@ -10,6 +10,7 @@ export interface InstallOptions {
 	client?: string;
 	clients?: string[];
 	local?: boolean;
+	all?: boolean;
 }
 
 export interface ListOptions {

--- a/packages/web/src/components/InstallSkill.tsx
+++ b/packages/web/src/components/InstallSkill.tsx
@@ -11,6 +11,9 @@ import { OpenCodeIcon } from "./ui/open-code";
 import { GithubIcon } from "./ui/github";
 import { AMPIcon } from "./ui/amp-icon";
 import { GeminiIcon } from "./ui/gemini-icon";
+import { HeartHandshakeIcon } from "./ui/heart-handshake-icon";
+import { OpenClawIcon } from "./ui/openclaw-icon";
+import { PiIcon } from "./ui/pi-icon";
 
 type Props = {
 	skill: Skill; // Skill to use in example instructions
@@ -46,7 +49,7 @@ const CLI_TARGETS: CliTarget[] = [
 	{
 		id: "shared",
 		name: "Shared",
-		icon: <PackageIcon size={16} />,
+		icon: <HeartHandshakeIcon size={16} />,
 		clientId: "shared",
 		description: "Installs to .agents/skills, used by Codex, Amp, Warp, Cursor, OpenCode, and more.",
 		projectPath: ".agents/skills",
@@ -63,7 +66,7 @@ const CLI_TARGETS: CliTarget[] = [
 	{
 		id: "openclaw",
 		name: "OpenClaw",
-		icon: <PackageIcon size={16} />,
+		icon: <OpenClawIcon size={16} />,
 		clientId: "openclaw",
 		description: "Installs to OpenClaw's skills folder.",
 		projectPath: "skills",
@@ -71,7 +74,7 @@ const CLI_TARGETS: CliTarget[] = [
 	{
 		id: "pi",
 		name: "Pi",
-		icon: <PackageIcon size={16} />,
+		icon: <PiIcon size={16} />,
 		clientId: "pi",
 		description: "Installs to Pi's coding agent skills folder.",
 		projectPath: ".pi/skills",

--- a/packages/web/src/components/InstallSkill.tsx
+++ b/packages/web/src/components/InstallSkill.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import { DownloadIcon } from "./ui/download";
 import { ClaudeCodeIcon, ClaudeIcon } from "@/components/ui/claude-icons";
 import { PackageIcon } from "@/components/ui/package-icon";
@@ -8,43 +9,73 @@ import { CodexIcon } from "./ui/codex-icon";
 import { CursorIcon } from "./ui/cursor-icon";
 import { OpenCodeIcon } from "./ui/open-code";
 import { GithubIcon } from "./ui/github";
-import { VSCodeIcon } from "./ui/vs-code-icon";
 import { AMPIcon } from "./ui/amp-icon";
-import { GooseIcon } from "./ui/goose-icon";
-import { LettaIcon } from "./ui/letta-icon";
 import { GeminiIcon } from "./ui/gemini-icon";
-import { WindsurfIcon } from "./ui/windsurf-icon";
-import { AntigravityIcon } from "./ui/antigravity-icon";
-import { TraeIcon } from "./ui/trae-icon";
-import { CodeBuddyIcon } from "./ui/codebuddy-icon";
-import { QoderIcon } from "./ui/qoder-icon";
+
 type Props = {
 	skill: Skill; // Skill to use in example instructions
 };
 
-type Client = {
-	id: string;
+type AgentBadge = {
 	name: string;
-	icon: React.ReactNode;
-	supportsGlobal: boolean;
+	icon: ReactNode;
 };
 
-const CLIENTS: Client[] = [
-	{ id: "claude", name: "Claude", icon: <ClaudeIcon />, supportsGlobal: false },
-	{ id: "claude-code", name: "Claude Code", icon: <ClaudeCodeIcon />, supportsGlobal: true },
-	{ id: "opencode", name: "Open Code", icon: <OpenCodeIcon />, supportsGlobal: true },
-	{ id: "amp", name: "Amp Code", icon: <AMPIcon />, supportsGlobal: true },
-	{ id: "codex", name: "Codex", icon: <CodexIcon />, supportsGlobal: true },
-	{ id: "cursor", name: "Cursor", icon: <CursorIcon />, supportsGlobal: false },
-	{ id: "vscode", name: "VS Code", icon: <VSCodeIcon />, supportsGlobal: false },
-	{ id: "letta", name: "Letta", icon: <LettaIcon />, supportsGlobal: false },
-	{ id: "goose", name: "Goose", icon: <GooseIcon />, supportsGlobal: false },
-	{ id: "gemini", name: "Gemini CLI", icon: <GeminiIcon />, supportsGlobal: true },
-	{ id: "antigravity", name: "Antigravity", icon: <AntigravityIcon />, supportsGlobal: true },
-	{ id: "windsurf", name: "Windsurf", icon: <WindsurfIcon />, supportsGlobal: true },
-	{ id: "trae", name: "Trae", icon: <TraeIcon />, supportsGlobal: false },
-	{ id: "codebuddy", name: "CodeBuddy", icon: <CodeBuddyIcon />, supportsGlobal: true },
-	{ id: "qoder", name: "Qoder", icon: <QoderIcon />, supportsGlobal: true },
+type CliTarget = {
+	id: string;
+	name: string;
+	icon: ReactNode;
+	clientId: string;
+	description: string;
+	projectPath: string;
+	agents?: AgentBadge[];
+};
+
+const SHARED_AGENTS: AgentBadge[] = [
+	{ name: "Codex", icon: <CodexIcon /> },
+	{ name: "Amp", icon: <AMPIcon /> },
+	{ name: "Warp", icon: <PackageIcon size={14} /> },
+	{ name: "Cursor", icon: <CursorIcon /> },
+	{ name: "OpenCode", icon: <OpenCodeIcon /> },
+	{ name: "Cline", icon: <PackageIcon size={14} /> },
+	{ name: "Gemini CLI", icon: <GeminiIcon /> },
+	{ name: "GitHub Copilot", icon: <GithubIcon size={14} /> },
+];
+
+const CLI_TARGETS: CliTarget[] = [
+	{
+		id: "shared",
+		name: "Shared",
+		icon: <PackageIcon size={16} />,
+		clientId: "shared",
+		description: "Installs to .agents/skills, used by Codex, Amp, Warp, Cursor, OpenCode, and more.",
+		projectPath: ".agents/skills",
+		agents: SHARED_AGENTS,
+	},
+	{
+		id: "claude-code",
+		name: "Claude Code",
+		icon: <ClaudeCodeIcon />,
+		clientId: "claude-code",
+		description: "Installs to Claude Code's native skills folder.",
+		projectPath: ".claude/skills",
+	},
+	{
+		id: "openclaw",
+		name: "OpenClaw",
+		icon: <PackageIcon size={16} />,
+		clientId: "openclaw",
+		description: "Installs to OpenClaw's skills folder.",
+		projectPath: "skills",
+	},
+	{
+		id: "pi",
+		name: "Pi",
+		icon: <PackageIcon size={16} />,
+		clientId: "pi",
+		description: "Installs to Pi's coding agent skills folder.",
+		projectPath: ".pi/skills",
+	},
 ];
 
 export function InstallSkill({ skill }: Props) {
@@ -116,97 +147,95 @@ export function InstallSkill({ skill }: Props) {
 		);
 	};
 
-	const renderCliInstructions = (clientId: string, supportsGlobal: boolean) => {
-		const projectSkill = `skills-installer install ${skill.namespace} -p --client ${clientId}`;
-		const personalSkill = `skills-installer install ${skill.namespace} --client ${clientId}`;
+	const renderCliInstructions = (target: CliTarget) => {
+		const projectSkill = `skills-installer add ${skill.namespace} -p --client ${target.clientId}`;
+		const personalSkill = `skills-installer add ${skill.namespace} --client ${target.clientId}`;
 
 		return (
 			<div className="flex flex-col gap-4">
-				{supportsGlobal ? (
-					<>
-						<div className="flex flex-col gap-2">
-							<div className="flex items-center gap-2">
-								<span className="inline-flex items-center justify-center px-1.5 py-0.5 bg-muted/50 text-foreground rounded border border-border/30 text-[10px] font-semibold font-mono">
-									1.a
-								</span>
-								<span className="text-sm font-medium text-foreground">
-									As Personal Skill (default)
-								</span>
+				<div className="flex items-start gap-3 rounded-md border border-border/50 bg-muted/30 p-3">
+					<span className="mt-0.5 inline-flex size-8 flex-shrink-0 items-center justify-center rounded-md bg-background text-foreground [&_svg]:size-4">
+						{target.icon}
+					</span>
+					<div className="min-w-0 flex-1">
+						<h3 className="text-sm font-medium text-foreground">{target.name}</h3>
+						<p className="text-sm text-muted-foreground">{target.description}</p>
+						{target.agents ? (
+							<div className="mt-2 flex flex-wrap gap-1.5">
+								{target.agents.map((agent) => (
+									<span
+										key={agent.name}
+										className="inline-flex min-h-7 items-center gap-1 rounded-full border border-border/50 bg-background px-2 py-1 text-xs text-muted-foreground [&_svg]:size-3.5"
+									>
+										{agent.icon}
+										{agent.name}
+									</span>
+								))}
 							</div>
-							<p className="text-sm text-muted-foreground">
-								Applies to all projects globally.
-							</p>
-							<CommandBoxWithRunner command={personalSkill} />
-						</div>
-						<div className="flex flex-col gap-2">
-							<div className="flex items-center gap-2">
-								<span className="inline-flex items-center justify-center px-1.5 py-0.5 bg-muted/50 text-foreground rounded border border-border/30 text-[10px] font-semibold font-mono">
-									1.b
-								</span>
-								<span className="text-sm font-medium text-foreground">
-									As Project Skill
-								</span>
-							</div>
-							<p className="text-sm text-muted-foreground">
-								Applies to current project only. Run this command in your project root.
-							</p>
-							<CommandBoxWithRunner command={projectSkill} />
-						</div>
-					</>
-				) : (
+						) : null}
+					</div>
+				</div>
+
+				<div className="grid gap-3 lg:grid-cols-2">
 					<div className="flex flex-col gap-2">
-						<div className="flex items-center gap-2">
-							<span className="inline-flex items-center justify-center px-1.5 py-0.5 bg-muted/50 text-foreground rounded border border-border/30 text-[10px] font-semibold font-mono">
-								1
-							</span>
-							<span className="text-sm font-medium text-foreground">
-								Install as Project Skill
-							</span>
+						<div>
+							<span className="text-sm font-medium text-foreground">Personal</span>
+							<p className="text-sm text-muted-foreground">Available across projects.</p>
 						</div>
-						<p className="text-sm text-muted-foreground">
-							Run this command in your project root.
-						</p>
+						<CommandBoxWithRunner command={personalSkill} />
+					</div>
+					<div className="flex flex-col gap-2">
+						<div>
+							<span className="text-sm font-medium text-foreground">Project</span>
+							<p className="text-sm text-muted-foreground">Writes to {target.projectPath}.</p>
+						</div>
 						<CommandBoxWithRunner command={projectSkill} />
 					</div>
-				)}
+				</div>
 			</div>
 		);
 	};
 
 	return (
 		<div className="border border-border/50 rounded-lg bg-card/30 shadow backdrop-blur-sm p-2 py-3">
-			<Tabs defaultValue="claude" className="w-full" orientation="vertical">
+			<Tabs defaultValue="shared" className="w-full" orientation="vertical">
 				<div className="flex flex-col md:flex-row gap-6">
 					{/* Vertical tabs on the left */}
-					<div className="w-full md:w-auto md:overflow-x-visible md:min-h-[200px] md:max-h-[350px] overflow-auto">
+					<div className="w-full md:w-auto md:overflow-x-visible overflow-auto">
 						<TabsList className="w-fit md:flex-col md:h-fit">
-							{CLIENTS.map((client) => (
+							{CLI_TARGETS.map((target) => (
 								<TabsTrigger
-									key={client.id}
-									value={client.id}
+									key={target.id}
+									value={target.id}
 									className="gap-2 md:w-full md:justify-start whitespace-nowrap"
 								>
-									<span className="flex-shrink-0">{client.icon}</span>
-									<span>{client.name}</span>
+									<span className="flex-shrink-0 [&_svg]:size-4">{target.icon}</span>
+									<span>{target.name}</span>
 								</TabsTrigger>
 							))}
+							<TabsTrigger
+								value="claude"
+								className="gap-2 md:w-full md:justify-start whitespace-nowrap"
+							>
+								<span className="flex-shrink-0 [&_svg]:size-4"><ClaudeIcon /></span>
+								<span>Claude</span>
+							</TabsTrigger>
 						</TabsList>
 					</div>
 
 					{/* Content on the right */}
 					<div className="flex-1 min-h-[270px] overflow-hidden flex flex-col justify-between">
+						{CLI_TARGETS.map((target) => (
+							<TabsContent key={target.id} value={target.id} className="mt-0">
+								{renderCliInstructions(target)}
+							</TabsContent>
+						))}
 						<TabsContent value="claude" className="mt-0">
 							{renderClaudeInstructions()}
 						</TabsContent>
-						{CLIENTS.filter((c) => c.id !== "claude").map((client) => (
-							<TabsContent key={client.id} value={client.id} className="mt-0">
-								{renderCliInstructions(client.id, client.supportsGlobal)}
-							</TabsContent>
-						))}
 						{/* Note */}
 						<div className="text-xs text-muted-foreground bg-muted/50 p-3 rounded-md border border-border/50 mt-2">
-							<strong>Note:</strong> Please verify skill by going through its
-							instructions before using it.
+							<strong>Note:</strong> Review the skill instructions before using it.
 						</div>
 					</div>
 				</div>

--- a/packages/web/src/components/ui/heart-handshake-icon.tsx
+++ b/packages/web/src/components/ui/heart-handshake-icon.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { motion, useAnimation } from "motion/react";
+import type { HTMLAttributes, MouseEvent } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface HeartHandshakeIconHandle {
+	startAnimation: () => void;
+	stopAnimation: () => void;
+}
+
+interface HeartHandshakeIconProps extends HTMLAttributes<HTMLDivElement> {
+	size?: number;
+}
+
+const HeartHandshakeIcon = forwardRef<
+	HeartHandshakeIconHandle,
+	HeartHandshakeIconProps
+>(({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+	const controls = useAnimation();
+	const isControlledRef = useRef(false);
+
+	useImperativeHandle(ref, () => {
+		isControlledRef.current = true;
+		return {
+			startAnimation: () => controls.start("animate"),
+			stopAnimation: () => controls.start("normal"),
+		};
+	});
+
+	const handleMouseEnter = useCallback(
+		(e: MouseEvent<HTMLDivElement>) => {
+			if (isControlledRef.current) {
+				onMouseEnter?.(e);
+			} else {
+				controls.start("animate");
+			}
+		},
+		[controls, onMouseEnter],
+	);
+
+	const handleMouseLeave = useCallback(
+		(e: MouseEvent<HTMLDivElement>) => {
+			if (isControlledRef.current) {
+				onMouseLeave?.(e);
+			} else {
+				controls.start("normal");
+			}
+		},
+		[controls, onMouseLeave],
+	);
+
+	return (
+		<div
+			className={cn(className)}
+			onMouseEnter={handleMouseEnter}
+			onMouseLeave={handleMouseLeave}
+			{...props}
+		>
+			<motion.svg
+				animate={controls}
+				fill="none"
+				height={size}
+				initial="normal"
+				stroke="currentColor"
+				strokeLinecap="round"
+				strokeLinejoin="round"
+				strokeWidth="2"
+				style={{ originX: "50%", originY: "50%" }}
+				variants={{
+					normal: { scale: 1, rotate: 0 },
+					animate: {
+						scale: [1, 0.9, 1, 1, 1, 1, 1],
+						rotate: [0, 0, 0, -7, 7, -3, 0],
+						transition: {
+							duration: 0.7,
+							times: [0, 0.15, 0.3, 0.4, 0.55, 0.75, 1],
+							ease: "easeInOut",
+						},
+					},
+				}}
+				viewBox="0 0 24 24"
+				width={size}
+				xmlns="http://www.w3.org/2000/svg"
+			>
+				<path d="M19.414 14.414C21 12.828 22 11.5 22 9.5a5.5 5.5 0 0 0-9.591-3.676.6.6 0 0 1-.818.001A5.5 5.5 0 0 0 2 9.5c0 2.3 1.5 4 3 5.5l5.535 5.362a2 2 0 0 0 2.879.052 2.12 2.12 0 0 0-.004-3 2.124 2.124 0 1 0 3-3 2.124 2.124 0 0 0 3.004 0 2 2 0 0 0 0-2.828l-1.881-1.882a2.41 2.41 0 0 0-3.409 0l-1.71 1.71a2 2 0 0 1-2.828 0 2 2 0 0 1 0-2.828l2.823-2.762" />
+			</motion.svg>
+		</div>
+	);
+});
+
+HeartHandshakeIcon.displayName = "HeartHandshakeIcon";
+
+export { HeartHandshakeIcon };

--- a/packages/web/src/components/ui/heart-handshake-icon.tsx
+++ b/packages/web/src/components/ui/heart-handshake-icon.tsx
@@ -32,9 +32,8 @@ const HeartHandshakeIcon = forwardRef<
 
 	const handleMouseEnter = useCallback(
 		(e: MouseEvent<HTMLDivElement>) => {
-			if (isControlledRef.current) {
-				onMouseEnter?.(e);
-			} else {
+			onMouseEnter?.(e);
+			if (!isControlledRef.current) {
 				controls.start("animate");
 			}
 		},
@@ -43,9 +42,8 @@ const HeartHandshakeIcon = forwardRef<
 
 	const handleMouseLeave = useCallback(
 		(e: MouseEvent<HTMLDivElement>) => {
-			if (isControlledRef.current) {
-				onMouseLeave?.(e);
-			} else {
+			onMouseLeave?.(e);
+			if (!isControlledRef.current) {
 				controls.start("normal");
 			}
 		},

--- a/packages/web/src/components/ui/openclaw-icon.tsx
+++ b/packages/web/src/components/ui/openclaw-icon.tsx
@@ -1,0 +1,63 @@
+export const OpenClawIcon = ({ size = 28 }: { size?: number }) => {
+	return (
+		<svg
+			aria-label="OpenClaw"
+			fill="none"
+			height={size}
+			viewBox="0 0 16 16"
+			width={size}
+			xmlns="http://www.w3.org/2000/svg"
+		>
+			<rect width="16" height="16" fill="none" />
+			<g fill="#3a0a0d">
+				<rect x="1" y="5" width="1" height="3" />
+				<rect x="2" y="4" width="1" height="1" />
+				<rect x="2" y="8" width="1" height="1" />
+				<rect x="3" y="3" width="1" height="1" />
+				<rect x="3" y="9" width="1" height="1" />
+				<rect x="4" y="2" width="1" height="1" />
+				<rect x="4" y="10" width="1" height="1" />
+				<rect x="5" y="2" width="6" height="1" />
+				<rect x="11" y="2" width="1" height="1" />
+				<rect x="12" y="3" width="1" height="1" />
+				<rect x="12" y="9" width="1" height="1" />
+				<rect x="13" y="4" width="1" height="1" />
+				<rect x="13" y="8" width="1" height="1" />
+				<rect x="14" y="5" width="1" height="3" />
+				<rect x="5" y="11" width="6" height="1" />
+				<rect x="4" y="12" width="1" height="1" />
+				<rect x="11" y="12" width="1" height="1" />
+				<rect x="3" y="13" width="1" height="1" />
+				<rect x="12" y="13" width="1" height="1" />
+				<rect x="5" y="14" width="6" height="1" />
+			</g>
+			<g fill="#ff4f40">
+				<rect x="5" y="3" width="6" height="1" />
+				<rect x="4" y="4" width="8" height="1" />
+				<rect x="3" y="5" width="10" height="1" />
+				<rect x="3" y="6" width="10" height="1" />
+				<rect x="3" y="7" width="10" height="1" />
+				<rect x="4" y="8" width="8" height="1" />
+				<rect x="5" y="9" width="6" height="1" />
+				<rect x="5" y="12" width="6" height="1" />
+				<rect x="6" y="13" width="4" height="1" />
+			</g>
+			<g fill="#ff775f">
+				<rect x="1" y="6" width="2" height="1" />
+				<rect x="2" y="5" width="1" height="1" />
+				<rect x="2" y="7" width="1" height="1" />
+				<rect x="13" y="6" width="2" height="1" />
+				<rect x="13" y="5" width="1" height="1" />
+				<rect x="13" y="7" width="1" height="1" />
+			</g>
+			<g fill="#081016">
+				<rect x="6" y="5" width="1" height="1" />
+				<rect x="9" y="5" width="1" height="1" />
+			</g>
+			<g fill="#f5fbff">
+				<rect x="6" y="4" width="1" height="1" />
+				<rect x="9" y="4" width="1" height="1" />
+			</g>
+		</svg>
+	);
+};

--- a/packages/web/src/components/ui/pi-icon.tsx
+++ b/packages/web/src/components/ui/pi-icon.tsx
@@ -3,6 +3,7 @@ export const PiIcon = ({ size = 28 }: { size?: number }) => {
 		<svg
 			aria-label="Pi"
 			height={size}
+			role="img"
 			viewBox="0 0 800 800"
 			width={size}
 			xmlns="http://www.w3.org/2000/svg"

--- a/packages/web/src/components/ui/pi-icon.tsx
+++ b/packages/web/src/components/ui/pi-icon.tsx
@@ -1,0 +1,19 @@
+export const PiIcon = ({ size = 28 }: { size?: number }) => {
+	return (
+		<svg
+			aria-label="Pi"
+			height={size}
+			viewBox="0 0 800 800"
+			width={size}
+			xmlns="http://www.w3.org/2000/svg"
+		>
+			<rect width="800" height="800" fill="#111827" />
+			<path
+				fill="#fff"
+				fillRule="evenodd"
+				d="M165.29 165.29H517.36V400H400V517.36H282.65V634.72H165.29ZM282.65 282.65V400H400V282.65Z"
+			/>
+			<path fill="#fff" d="M517.36 400H634.72V634.72H517.36Z" />
+		</svg>
+	);
+};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `add` alias for `install` and `--all` flag to install all resolved skills
  * New install targets: shared, claude-code, openclaw, pi

* **Documentation**
  * Updated CLI docs, examples, client-targeting, agent aliases, and install-path guidance

* **UI Improvements**
  * Redesigned installer UI with Personal/Project command blocks, target badges/icons, and an animated icon component

* **Chores**
  * Package version bumped to 0.3.0

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kamalnrf/claude-plugins/pull/108)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->