### PR TITLE
Bypass custom domain for web registry fetches

### DIFF
--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -1,4 +1,9 @@
-const REGISTRY_BASE = "https://api.claude-plugins.dev";
+const DEFAULT_REGISTRY_BASE =
+	"https://kamalnrf--44867e10a75311f08f880224a6c84d84.web.val.run";
+
+export const REGISTRY_BASE = (
+	import.meta.env.REGISTRY_API_URL || DEFAULT_REGISTRY_BASE
+).replace(/\/$/, "");
 const MAX_RETRIES = 3;
 const INITIAL_DELAY_MS = 500; // Exponential backoff: 500ms, 1000ms, 2000ms
 

--- a/packages/web/src/pages/api/download.ts
+++ b/packages/web/src/pages/api/download.ts
@@ -1,4 +1,5 @@
 import type { APIRoute } from "astro";
+import { REGISTRY_BASE } from "../../lib/api";
 
 export const GET: APIRoute = async ({ request }) => {
 	const url = new URL(request.url);
@@ -26,7 +27,7 @@ export const GET: APIRoute = async ({ request }) => {
 	// 3. Fetch skill to get sourceUrl
 	try {
 		const skillResponse = await fetch(
-			`https://api.claude-plugins.dev/api/skills/${owner}/${marketplace}/${skillName}`,
+			`${REGISTRY_BASE}/api/skills/${owner}/${marketplace}/${skillName}`,
 		);
 
 		if (!skillResponse.ok) {
@@ -51,7 +52,7 @@ export const GET: APIRoute = async ({ request }) => {
 
 		// 5. Track install ONLY after successful zip fetch (fire-and-forget)
 		fetch(
-			`https://api.claude-plugins.dev/api/skills/${owner}/${marketplace}/${skillName}/install`,
+			`${REGISTRY_BASE}/api/skills/${owner}/${marketplace}/${skillName}/install`,
 			{ method: "POST" },
 		).catch((err) => console.error("Tracking failed:", err));
 


### PR DESCRIPTION
## Summary
- default the web app's server-side registry API client to the direct Val Town endpoint
- keep a private `REGISTRY_API_URL` override for future upstream changes
- route the download proxy through the same registry base instead of hardcoding `api.claude-plugins.dev`

## Why
Vercel server-side fetches to `api.claude-plugins.dev` currently traverse `domains.val.run -> in.saascustomdomains.com`, which appears to be the layer producing intermittent upstream 429s during bursty cache revalidation. The direct `web.val.run` endpoint bypasses that custom-domain CNAME path.

## Verification
- `bun run web:build`

Note: the build completed successfully; Astro/Vercel emitted the existing local Node 24 vs Vercel Node 22 warning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated registry API endpoint configuration to support environment-based settings with automatic URL normalization, replacing hardcoded values.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kamalnrf/claude-plugins/pull/109)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->