### PR TITLE
[codex] fix shared skills install path

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -30,7 +30,7 @@
     },
     "packages/skills-installer": {
       "name": "skills-installer",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "bin": {
         "skills-installer": "./dist/cli.js",
       },

--- a/packages/skills-installer/README.md
+++ b/packages/skills-installer/README.md
@@ -150,7 +150,7 @@ Skills can be identified using multiple formats:
 
 | Client | Project path | Global path |
 |--------|--------------|-------------|
-| `shared` | `./.agents/skills/` | `~/.config/agents/skills/` |
+| `shared` | `./.agents/skills/` | `~/.agents/skills/` |
 | `claude-code` | `./.claude/skills/` | `~/.claude/skills/` |
 | `openclaw` | `./skills/` | `~/.openclaw/skills/` |
 | `pi` | `./.pi/skills/` | `~/.pi/agent/skills/` |

--- a/packages/skills-installer/package.json
+++ b/packages/skills-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skills-installer",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Install agent skills across multiple clients that support agentskills.io",
   "type": "module",
   "bin": {

--- a/packages/skills-installer/src/commands/list.ts
+++ b/packages/skills-installer/src/commands/list.ts
@@ -85,10 +85,9 @@ export async function list(options: ListOptions): Promise<void> {
 	// Group by client
 	const grouped = installedSkills.reduce(
 		(acc, skill) => {
-			if (!acc[skill.client]) {
-				acc[skill.client] = [];
-			}
-			acc[skill.client].push(skill);
+			const clientSkills = acc[skill.client] ?? [];
+			clientSkills.push(skill);
+			acc[skill.client] = clientSkills;
 			return acc;
 		},
 		{} as Record<string, InstalledSkill[]>,

--- a/packages/skills-installer/src/lib/client-config.test.ts
+++ b/packages/skills-installer/src/lib/client-config.test.ts
@@ -1,0 +1,22 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+import { getClientConfig } from "./client-config";
+
+describe("client config", () => {
+	test("shared installs globally to ~/.agents/skills", () => {
+		expect(getClientConfig("shared")?.globalDir).toBe(
+			join(homedir(), ".agents", "skills"),
+		);
+	});
+
+	test("shared installs locally to the project .agents/skills directory", () => {
+		expect(getClientConfig("shared")?.localDir).toBe(
+			join(process.cwd(), ".agents", "skills"),
+		);
+	});
+
+	test("shared aliases use the shared .agents/skills config", () => {
+		expect(getClientConfig("codex")).toBe(getClientConfig("shared"));
+	});
+});

--- a/packages/skills-installer/src/lib/client-config.ts
+++ b/packages/skills-installer/src/lib/client-config.ts
@@ -4,7 +4,6 @@ import { join } from "node:path";
 import type { ClientConfig } from "../types.js";
 
 const home = homedir();
-const configHome = process.env.XDG_CONFIG_HOME?.trim() || join(home, ".config");
 const claudeHome = process.env.CLAUDE_CONFIG_DIR?.trim() || join(home, ".claude");
 
 const getOpenClawGlobalDir = (): string | undefined => {
@@ -23,7 +22,7 @@ const getOpenClawGlobalDir = (): string | undefined => {
 export const CLIENT_CONFIGS: Record<string, ClientConfig> = {
 	"shared": {
 		name: "Shared (.agents/skills)",
-		globalDir: join(configHome, "agents", "skills"),
+		globalDir: join(home, ".agents", "skills"),
 		localDir: join(process.cwd(), ".agents", "skills"),
 	},
 	"claude-code": {


### PR DESCRIPTION
## Summary

- Point the `skills-installer` shared client global install path at `~/.agents/skills` instead of `~/.config/agents/skills`.
- Add regression coverage for shared global, shared project, and shared alias path resolution.
- Bump `skills-installer` from `0.3.0` to `0.3.1` for the fix release.
- Update the installer README path table to match the actual shared target.
- Clean up a strict TypeScript issue in `list.ts` that surfaced while validating the package.

## Root Cause

The recent shared-client support wired the global shared install target to the XDG-style `~/.config/agents/skills` path. Agents are expected to read the shared directory from `~/.agents/skills`, so installs with `--client shared` succeeded but landed in the wrong global directory.

## Validation

- `bun test` in `packages/skills-installer` passes: 18 tests.
- `bunx tsc -p packages/skills-installer/tsconfig.json` passes.
- `bun run build` in `packages/skills-installer` passes.
- Deleted `~/.agents/skills/agent-browser`, then verified the rebuilt local CLI installs `@vercel-labs/agent-browser/agent-browser --client shared` to `~/.agents/skills/agent-browser/SKILL.md`.
- Verified `--client shared --project` installs to `<cwd>/.agents/skills/agent-browser/SKILL.md` from a temporary project directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the shared client's global skills directory installation path to `~/.agents/skills/`, reflecting improved and more streamlined directory organization for enhanced user experience

* **Chores**
  * Package version bumped to 0.3.1
  * Optimized the internal skill grouping mechanism for better performance and overall reliability
  * Added comprehensive tests for client configuration validation and verification

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kamalnrf/claude-plugins/pull/111?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->