### PR TITLE
Fix tweet embed entity handling

### DIFF
--- a/packages/web/src/components/Tweet.astro
+++ b/packages/web/src/components/Tweet.astro
@@ -14,14 +14,42 @@ try {
   console.error(`Failed to fetch tweet ${id}:`, error);
   tweet = undefined;
 }
-const hasVideo = tweet?.mediaDetails?.some(m => m.type === 'video' || m.type === 'animated_gif');
-const tweetUrl = tweet ? `https://twitter.com/${tweet.user.screen_name}/status/${id}` : '';
+
+const normalizeTweet = (value: any) => {
+  if (!(
+    value &&
+    typeof value.id_str === 'string' &&
+    typeof value.text === 'string' &&
+    Array.isArray(value.display_text_range) &&
+    value.user &&
+    typeof value.user.name === 'string' &&
+    typeof value.user.screen_name === 'string' &&
+    typeof value.user.profile_image_url_https === 'string'
+  )) {
+    return undefined;
+  }
+
+  return {
+    ...value,
+    entities: {
+      hashtags: [],
+      user_mentions: [],
+      urls: [],
+      symbols: [],
+      ...value.entities,
+    },
+  };
+};
+
+const normalizedTweet = normalizeTweet(tweet);
+const hasVideo = normalizedTweet?.mediaDetails?.some(m => m.type === 'video' || m.type === 'animated_gif');
+const tweetUrl = normalizedTweet ? `https://twitter.com/${normalizedTweet.user.screen_name}/status/${id}` : '';
 const fallbackUrl = `https://twitter.com/i/web/status/${id}`;
 ---
 
 <div class="tweet-embed max-w-[600px] mx-auto" data-theme="dark" data-has-video={hasVideo} data-tweet-url={tweetUrl}>
-  {tweet ? (
-    <EmbeddedTweet tweet={tweet} />
+  {normalizedTweet ? (
+    <EmbeddedTweet tweet={normalizedTweet} />
   ) : (
     <a
       href={fallbackUrl}

--- a/packages/web/src/components/Tweet.astro
+++ b/packages/web/src/components/Tweet.astro
@@ -1,6 +1,6 @@
 ---
 import { getTweet } from 'react-tweet/api';
-import { EmbeddedTweet, TweetNotFound } from 'react-tweet';
+import { EmbeddedTweet } from 'react-tweet';
 
 interface Props {
   id: string;
@@ -16,10 +16,22 @@ try {
 }
 const hasVideo = tweet?.mediaDetails?.some(m => m.type === 'video' || m.type === 'animated_gif');
 const tweetUrl = tweet ? `https://twitter.com/${tweet.user.screen_name}/status/${id}` : '';
+const fallbackUrl = `https://twitter.com/i/web/status/${id}`;
 ---
 
 <div class="tweet-embed max-w-[600px] mx-auto" data-theme="dark" data-has-video={hasVideo} data-tweet-url={tweetUrl}>
-  {tweet ? <EmbeddedTweet tweet={tweet} /> : <TweetNotFound />}
+  {tweet ? (
+    <EmbeddedTweet tweet={tweet} />
+  ) : (
+    <a
+      href={fallbackUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      class="block rounded-lg border border-border/50 bg-card/30 p-4 text-sm text-muted-foreground hover:bg-muted/30"
+    >
+      View usage example on Twitter/X
+    </a>
+  )}
 </div>
 
 <script>

--- a/packages/web/src/pages/skills/[...slug].astro
+++ b/packages/web/src/pages/skills/[...slug].astro
@@ -7,7 +7,6 @@ import { SkillDetailHeader } from "@/components/SkillDetailHeader";
 import Markdown from "@/components/Markdown.astro";
 import { Button } from "@/components/ui/button";
 import {LinkIcon} from '@/components/ui/link-icon'
-import Tweet from '@/components/Tweet.astro';
 
 const { slug } = Astro.params;
 const parts = slug?.split("/") || [];
@@ -77,8 +76,19 @@ Astro.response.headers.set('Cache-Control', 'public, max-age=0, must-revalidate,
 					<h2 class="text-base font-semibold text-foreground/90 tracking-tight">Skill Usage</h2>
 					<div class="flex-1 h-px bg-border/30"></div>
 				</div>
-				<div class="flex justify-center">
-					<Tweet id="2011227015337455694" />
+				<div class="rounded-lg border border-border/50 bg-card/30 p-4 text-sm text-muted-foreground">
+					<p>
+						Use this skill when you need to find or install a more specialized Agent Skill before starting work.
+					</p>
+					<a
+						href="https://twitter.com/noominoid/status/2011227015337455694"
+						target="_blank"
+						rel="noopener noreferrer"
+						class="mt-3 inline-flex items-center gap-1 text-primary hover:underline"
+					>
+						View usage example
+						<LinkIcon />
+					</a>
 				</div>
 			</section>
 		)}

--- a/packages/web/src/pages/skills/[...slug].astro
+++ b/packages/web/src/pages/skills/[...slug].astro
@@ -7,6 +7,7 @@ import { SkillDetailHeader } from "@/components/SkillDetailHeader";
 import Markdown from "@/components/Markdown.astro";
 import { Button } from "@/components/ui/button";
 import {LinkIcon} from '@/components/ui/link-icon'
+import Tweet from '@/components/Tweet.astro';
 
 const { slug } = Astro.params;
 const parts = slug?.split("/") || [];
@@ -76,19 +77,8 @@ Astro.response.headers.set('Cache-Control', 'public, max-age=0, must-revalidate,
 					<h2 class="text-base font-semibold text-foreground/90 tracking-tight">Skill Usage</h2>
 					<div class="flex-1 h-px bg-border/30"></div>
 				</div>
-				<div class="rounded-lg border border-border/50 bg-card/30 p-4 text-sm text-muted-foreground">
-					<p>
-						Use this skill when you need to find or install a more specialized Agent Skill before starting work.
-					</p>
-					<a
-						href="https://twitter.com/noominoid/status/2011227015337455694"
-						target="_blank"
-						rel="noopener noreferrer"
-						class="mt-3 inline-flex items-center gap-1 text-primary hover:underline"
-					>
-						View usage example
-						<LinkIcon />
-					</a>
+				<div class="flex justify-center">
+					<Tweet id="2011227015337455694" />
 				</div>
 			</section>
 		)}


### PR DESCRIPTION
## Summary
- Keep the skills-discovery Skill Usage section rendering the tweet embed.
- Normalize Twitter syndication payloads before passing them to react-tweet.
- Add default hashtags, user_mentions, urls, and symbols arrays because react-tweet assumes they exist but Twitter may omit empty entity groups.
- Fall back to a direct Twitter/X status link if the payload is not a valid tweet shape.

## Verification
- bun run web:build
- Local route check returned 200 OK for /skills/@Kamalnrf/claude-plugins/skills-discovery.
- Local route rendered the full tweet embed and tweet text.
- Local route response did not include Internal server error.

## Notes
- Root cause: the current tweet payload has entities.media and entities.urls but omits empty entities.hashtags, entities.user_mentions, and entities.symbols. react-tweet iterates those arrays during render, which can throw and surface as Internal server error.
- Existing unrelated untracked .quire/ and AGENTS.md files were not included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * When an embedded tweet is unavailable, the component now shows a styled external link ("View usage example on Twitter/X") to the tweet instead of an error placeholder.

* **Bug Fixes**
  * Tweet embed data is normalized so missing fields no longer break rendering; media click behavior still enhances video-only embeds when a tweet URL is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->