### PR TITLE
fix: correct search endpoint in API reference table

### DIFF
--- a/skills/skills-discovery/SKILL.md
+++ b/skills/skills-discovery/SKILL.md
@@ -176,7 +176,7 @@ Present results and ask which to install.
 
 | Endpoint                                 | Description       |
 | ---------------------------------------- | ----------------- |
-| `GET /api/skills/search?q=QUERY`         | Search skills     |
+| `GET /api/skills?q=QUERY`                | Search skills     |
 | `GET /api/skills/@owner/repo/skill-name` | Get skill details |
 
 **Web registry:** https://claude-plugins.dev/skills


### PR DESCRIPTION
> **Automated**: drive-by fix from [NLPM](https://github.com/xiaolai/nlpm), an NL artifact linter. Reviewed and reproduced before submission.

**Bug**: The API reference table documents the search endpoint as `GET /api/skills/search?q=QUERY`, but that route does not exist — no `skills/search.ts` file is present in `packages/web/src/pages/api/`; the actual route is `packages/web/src/pages/api/skills.ts`, which serves `GET /api/skills?q=QUERY`. The workflow body (line 32) and both examples (lines 150, 170) already use the correct path.

**Evidence**: `packages/web/src/pages/api/` contains `skills.ts`, `download.ts`, and `plugins.ts` — no `search.ts` or `skills/search.ts`; a request to `/api/skills/search?q=...` returns 404.

**Fix**: Updated the reference table to match the actual implemented endpoint: `GET /api/skills?q=QUERY`.

<!-- nlpm-metadata-begin
{"version":1,"findings":[]}
nlpm-metadata-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the skills search API endpoint documentation to reflect the current endpoint path structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->