### PR TITLE
fix: pin skills-installer to version 0.3.1 in npx calls

### DIFF
--- a/skills/skills-discovery/SKILL.md
+++ b/skills/skills-discovery/SKILL.md
@@ -96,22 +96,22 @@ Determine which client the user is working in before installing. If unclear, ask
 - **Client selection:**
 
 ```bash
-npx skills-installer install @owner/repo/skill-name --client claude-code  # default
-npx skills-installer install @owner/repo/skill-name --client cursor
-npx skills-installer install @owner/repo/skill-name --client vscode
+npx skills-installer@0.3.1 install @owner/repo/skill-name --client claude-code  # default
+npx skills-installer@0.3.1 install @owner/repo/skill-name --client cursor
+npx skills-installer@0.3.1 install @owner/repo/skill-name --client vscode
 ```
 
 **Scope selection:**
 
 ```bash
-npx skills-installer install @owner/repo/skill-name  # global (default)
-npx skills-installer install @owner/repo/skill-name --local  # project-specific
+npx skills-installer@0.3.1 install @owner/repo/skill-name  # global (default)
+npx skills-installer@0.3.1 install @owner/repo/skill-name --local  # project-specific
 ```
 
 **Combined:**
 
 ```bash
-npx skills-installer install @owner/repo/skill-name --client cursor --local
+npx skills-installer@0.3.1 install @owner/repo/skill-name --client cursor --local
 ```
 
 **Defaults:**
@@ -123,10 +123,10 @@ npx skills-installer install @owner/repo/skill-name --client cursor --local
 
 ```bash
 # List installed skills
-npx skills-installer list
+npx skills-installer@0.3.1 list
 
 # Uninstall a skill
-npx skills-installer uninstall @owner/repo/skill-name
+npx skills-installer@0.3.1 uninstall @owner/repo/skill-name
 ```
 
 ## Presenting results to users


### PR DESCRIPTION
> **Automated**: drive-by fix from [NLPM](https://github.com/xiaolai/nlpm), an NL artifact linter. Reviewed and reproduced before submission.

**Bug**: All `npx skills-installer` calls in `skills/skills-discovery/SKILL.md` run without a version pin, so every invocation fetches whatever version is currently latest on npm; a compromised release would silently execute arbitrary code in the user's environment.

**Evidence**: `packages/skills-installer/package.json` declares version `0.3.1`; `npx skills-installer install` (no `@version`) resolves to the floating latest at run time — confirmed by npm's npx resolution semantics (no cache pin when no version is specified).

**Fix**: Appended `@0.3.1` to every `npx skills-installer` invocation in the skill, matching the version declared in this repo.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"SEC-unpinned-semver","fingerprint":"sha256:b889aeecd567cc0b1f826d188fbac3c4a49c6a964f166e8eb294b7edf6dad320"}]}
nlpm-metadata-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation and management command examples for `skills-installer` CLI
  * Pinned CLI version to 0.3.1 in all example commands
  * Added clarifying section headings to improve readability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->