### PR TITLE
fix: pin @types/bun devDependency to ^1.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "type": "module",
   "devDependencies": {
-    "@types/bun": "latest"
+    "@types/bun": "^1.3.1"
   },
   "peerDependencies": {
     "typescript": "^5"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -42,7 +42,7 @@
     "picocolors": "^1.1.1"
   },
   "devDependencies": {
-    "@types/bun": "latest"
+    "@types/bun": "^1.3.1"
   },
   "peerDependencies": {
     "typescript": "^5"


### PR DESCRIPTION
> **Automated**: drive-by fix from [NLPM](https://github.com/xiaolai/nlpm), an NL artifact linter. Reviewed and reproduced before submission.

**Bug**: Both `package.json` and `packages/cli/package.json` declare `"@types/bun": "latest"` — the floating `latest` tag resolves to whatever version is current at install time, meaning a breaking type change in a future `@types/bun` release silently breaks builds without any version boundary to bisect against.

**Evidence**: `bun.lock` already pins the resolved version to `@types/bun@1.3.1`, confirming the repo was last validated against that version; the package.json constraint does not reflect this.

**Fix**: Replaced `"latest"` with `"^1.3.1"` in both `package.json` and `packages/cli/package.json`, matching the lockfile-resolved baseline.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"SEC-unpinned-semver","fingerprint":"sha256:e8af1d2d1082379a6525ac217ff1231cae4416310619706c8d9dd61121e2d4fe"}]}
nlpm-metadata-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Locked `@types/bun` development dependency to a fixed version for improved reproducibility and stability across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->